### PR TITLE
Add Travis CI & Truffle Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+  - "8.11.4"
+
+cache:
+  directories:
+    - "node_modules"
+
+before_install:
+  - npm i -g ganache-cli@6.1.0 truffle@4.1.14
+  - ganache-cli &>/dev/null &
+  - sleep 6 # wait for ganache-cli, can remove once local deps need to be installed
+
+script:
+ - curl -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":0}' http://localhost:8545
+ - truffle test


### PR DESCRIPTION
This PR adds a travis config, and truffle test.

Travis CI will need to be turned on for the repo, a badge can be added to the root readme once it has been created.