### PR TITLE
Persist data on IPFS

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -13,12 +13,18 @@ config.account = {
   privateKey: "43321939fdfa64cd3f9cf8e05fabf86600c8f349e7cb444f6d23b31f60d4095c"
 }
 
+config.ipfsOpts = {
+  host: "localhost",
+  port: "5001",
+  protocol: "http"
+};
+
 config.EthDIDAnchorContractAddress = "0xdb1e4e5c1b8741d741c87d1a6a08b31ff4d25826";
 
 config.WEB_PORT = 3000; // APIs
 
 if (process.env.NODE_ENV == "production") {
-  // TODO: read account information from the environment
+  // TODO: read config from the environment
 }
 
 module.exports = config;

--- a/db/index.js
+++ b/db/index.js
@@ -1,5 +1,6 @@
 let memoryStore = {};
 
+// The anchorHash is the merkle root hash
 function addHash(anchorHash, ipfsHash, transactionNumber) {
   memoryStore[transactionNumber] = {anchorHash, ipfsHash};
 }

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1,0 +1,34 @@
+const bs58 = require("bs58");
+
+// https://ethereum.stackexchange.com/a/39961/37119
+// Fits the ipfs hash into 32 bytes
+function getBytes32FromSHA256Hash(hash) {
+  return "0x"+bs58.decode(hash).slice(2).toString('hex');
+}
+
+// Reconstructs a multihash from bytes32
+function getMultiHashFromBytes32(bytes32Hex) {
+  // Add our default ipfs values for first 2 bytes:
+  // function:0x12=sha2, size:0x20=256 bits
+  // and cut off leading "0x"
+  const hashHex = "1220" + bytes32Hex.slice(2)
+  const hashBytes = Buffer.from(hashHex, 'hex');
+  const hashStr = bs58.encode(hashBytes)
+  return hashStr;
+}
+ 
+function encodeBase58FromString(data) {
+  const bytes = Buffer.from(data, "utf8");
+  return bs58.encode(bytes);
+}
+
+function decodeBase58ToString(data) {
+  const bytes = bs58.decode(data);
+  return bytes.toString("utf8");
+}
+
+function encodeBase58FromBuffer(bytes) {
+  return bs58.encode(bytes);
+}
+
+module.exports = {encodeBase58FromString, decodeBase58ToString, getBytes32FromSHA256Hash, getMultiHashFromBytes32, encodeBase58FromBuffer}

--- a/lib/ipfs.js
+++ b/lib/ipfs.js
@@ -1,0 +1,6 @@
+const ipfsAPI = require("ipfs-api");
+const config = require("../config");
+ 
+const ipfs = ipfsAPI(config.ipfsOpts);
+
+module.exports = ipfs;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,7 +1795,7 @@
     },
     "ethereumjs-util": {
       "version": "4.5.0",
-      "resolved": "http://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
       "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
       "requires": {
         "bn.js": "4.11.6",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "supertest": "^3.3.0"
   },
   "dependencies": {
+    "bs58": "^4.0.1",
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-tx": "^1.3.5",
     "ipfs-api": "^25.0.0",
     "koa": "^2.6.1",
     "koa-bodyparser": "^4.2.1",
     "koa-router": "^7.4.0",
+    "multihashes": "^0.4.14",
     "truffle-contract": "^3.0.6",
     "web3": "^0.20.6"
   }

--- a/services/cas.js
+++ b/services/cas.js
@@ -2,9 +2,16 @@
  * Content addressable storage
  */
 
-async function fetchDataAtAddress(CASAddress) {
-  // TODO: implement this!
-  return "T7xykxQiS3ES8L2u3hTFVGWEW6er5vcsLpV9RGvpcHL9oriypeNWiNSAbJUoymkDUD9vskc5uEfd3St2K4VDcGEPZsCRtkUq6bJ1SAm1DJyNSdkx";
+const ipfs = require("../lib/ipfs");
+
+async function fetchBufferAtAddress(CASAddress) {
+  const ipfsData = await ipfs.files.get(CASAddress);
+  return ipfsData[0].content;
 }
 
-module.exports = { fetchDataAtAddress }
+async function putBuffer(bufferData) {
+  const address = await ipfs.files.add(bufferData);
+  return address;
+}
+
+module.exports = { fetchBufferAtAddress, putBuffer }

--- a/services/transactions.js
+++ b/services/transactions.js
@@ -1,25 +1,20 @@
 const cas = require("./cas");
 const blockchain = require("./blockchain");
+const encoding = require("../lib/encoding");
 
 /**
 * https://github.com/decentralized-identity/sidetree-core/blob/master/docs/protocol.md#anchor-file-schema
 */
-async function anchorNewHash(anchorHashCASAddress) {
-  return cas.fetchDataAtAddress(anchorHashCASAddress).then(async (hashData) => {
-    // hashData is base58 encoded.  It decodes into an object with these keys:
+async function anchorNewHash(anchorFileHash) {
+  return cas.fetchBufferAtAddress(anchorFileHash).then(async (hashData) => {
+    // hashData is a buffer of a base58 encoded string.  It decodes into an object the keys:
     //   "batchFileHash": "Base58 encoded hash of the batch file."
-    //   "merkleRoot": "Base58 encoded root hash of the Merkle tree constructed
-    // using the batch file."
-
-    // TODO decode hashData
-    let decoded = {
-      "batchFileHash": "StV1DL6CwTryKyV",
-      "merkleRoot": "9CiwA8tmydLojNKvt3"
-    }
+    //   "merkleRoot": "Base58 encoded root hash of the Merkle tree of the batch file."
+    let decoded = JSON.parse(encoding.decodeBase58ToString(hashData.toString()));
 
     // Call the Smart Contract service to persist the merkleRoot and the ipfsHash
     // and return the ethereum transaction number
-    return await blockchain.addAnchorHash(decoded.merkleRoot, anchorHashCASAddress);
+    return await blockchain.addAnchorHash(decoded.merkleRoot, anchorFileHash);
   })
 }
 


### PR DESCRIPTION
#10 

This PR:

- adds an IPFS module
- uses the multihash format for hashes
- funges the multihash to fit into a bytes32 field in the contract